### PR TITLE
First pass at a Speaker Notes GUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,8 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "codemirror": "^5.18.0",
+    "cuid": "^1.3.8",
+    "qs": "^6.3.0",
     "react-virtualized-select": "^2.1.0",
     "styled-components": "^1.0.8"
   },

--- a/source/modules/Code.js
+++ b/source/modules/Code.js
@@ -54,7 +54,7 @@ export default class Code extends Component {
   }
 
   render () {
-    const { codeMirrorOptions, value } = this.props
+    const { codeMirrorOptions, value, className } = this.props
 
     const options = {
       ...DEFAULT_CODE_MIRROR_OPTIONS,
@@ -62,7 +62,7 @@ export default class Code extends Component {
     }
 
     return (
-      <CodeMirrorTheme>
+      <CodeMirrorTheme className={className}>
         <CodeMirror
           options={options}
           ref={(ref) => {

--- a/source/modules/Presentation.js
+++ b/source/modules/Presentation.js
@@ -210,9 +210,11 @@ export default class Presentation extends Component {
 
     switch (event.key) {
       case 'ArrowLeft':
+      case 'PageUp':
         this.goBack()
         break
       case 'ArrowRight':
+      case 'PageDown':
       case 'Enter':
       case ' ':
         this.goForward()

--- a/source/modules/Presentation.js
+++ b/source/modules/Presentation.js
@@ -1,8 +1,12 @@
 import React, { Component, PropTypes } from 'react'
 import { HashRouter, Match, Redirect } from 'react-router'
+import cuid from 'cuid'
+import qs from 'qs'
 import DefaultTheme from './DefaultTheme'
 import { presentationContext } from './PropTypes'
 import TouchNav from './TouchNav'
+
+const crossWindowCallbackName = cuid()
 
 export default class Presentation extends Component {
   static childContextTypes = {
@@ -28,13 +32,40 @@ export default class Presentation extends Component {
     this._slideIndexMap = {}
     this._stepIndex = 0
 
+    // Handle to other window containing notes
+    this._notesWindowHandle = null
+
+    // When this window is the notes window, this is the ID passed in for
+    // execution by the window with the slides
+    this._attachedCallbackName = ''
+
     this.getPatternForSlide = this.getPatternForSlide.bind(this)
     this.getSlideIndex = this.getSlideIndex.bind(this)
     this.getStepIndex = this.getStepIndex.bind(this)
     this.goBack = this.goBack.bind(this)
     this.goForward = this.goForward.bind(this)
     this.goToSlide = this.goToSlide.bind(this)
+    this.showNotes = this.showNotes.bind(this)
+    this.signalParent = this.signalParent.bind(this)
     this._onKeyDown = this._onKeyDown.bind(this)
+  }
+
+  componentWillMount () {
+    const callbackFunc = (path) => {
+      this._router.replaceWith(path)
+    }
+
+    // Detect if we are a notes window, or a slides window
+    this._attachedCallbackName = qs.parse(window.location.search.slice(1)).notes
+    this._isNotesWindow = !!this._attachedCallbackName
+
+    if (!this._isNotesWindow && !window[crossWindowCallbackName]) {
+      // attach a function for the notes window to call
+      window[crossWindowCallbackName] = callbackFunc
+    } else if (this._isNotesWindow && !window[this._attachedCallbackName]) {
+      // attach a function for the parent window to call
+      window[this._attachedCallbackName] = callbackFunc
+    }
   }
 
   componentDidMount () {
@@ -58,6 +89,19 @@ export default class Presentation extends Component {
     this._index++
 
     return this._createPath({ slideIndex })
+  }
+
+  getIndexForSlide (slide) {
+    let slideIndex = -1
+    Object.keys(this._slideIndexMap).some(index => {
+      if (this._slideIndexMap[index] === slide) {
+        slideIndex = parseInt(index, 10)
+        return true
+      }
+      return false
+    })
+
+    return slideIndex
   }
 
   getSlideIndex () {
@@ -136,11 +180,56 @@ export default class Presentation extends Component {
       const path = this._createPath({ slideIndex, stepIndex })
 
       this._router.replaceWith(path)
+
+      if (this._isNotesWindow) {
+        this.signalParent(path)
+      } else if (this._notesWindowHandle) {
+        this.showNotes(path)
+      }
+    }
+  }
+
+  signalParent (path) {
+    if (!window.opener) {
+      return
+    }
+    window.opener[this._attachedCallbackName](path)
+  }
+
+  showNotes (path) {
+    if (this._notesWindowHandle && !this._notesWindowHandle.closed) {
+      this._notesWindowHandle[crossWindowCallbackName](path)
+    } else {
+      const notesUrl = new window.URL(window.location.href)
+
+      // inject the 'notes' query string
+      notesUrl.search = `?${qs.stringify(
+        Object.assign(
+          qs.parse(window.location.search.slice(1)),
+          { notes: crossWindowCallbackName }
+        )
+      )}`
+
+      this._notesWindowHandle = window.open(notesUrl.toString(), 'react-presents-notes')
     }
   }
 
   render () {
     const { children, disableTheme, router: Router } = this.props
+
+    const renderedChildren = typeof children === 'function'
+      ? children({ presentation: this })
+      : children
+
+    let renderedContents
+
+    if (this._isNotesWindow) {
+      renderedContents = React.Children.map(renderedChildren, child => (
+        React.cloneElement(child, { showNotes: true })
+      ))
+    } else {
+      renderedContents = renderedChildren
+    }
 
     return (
       <Router>
@@ -167,10 +256,7 @@ export default class Presentation extends Component {
                 )}
               />
 
-              {typeof children === 'function'
-                ? children({ presentation: this })
-                : children
-              }
+              {renderedContents}
 
               <TouchNav />
             </div>
@@ -209,6 +295,12 @@ export default class Presentation extends Component {
     }
 
     switch (event.key) {
+      case 's':
+      case 'S':
+        if (!this._isNotesWindow) {
+          this.showNotes()
+        }
+        break
       case 'ArrowLeft':
         this.goBack()
         break

--- a/source/modules/Slide.js
+++ b/source/modules/Slide.js
@@ -13,7 +13,8 @@ export default class Slide extends Component {
 
   static propTypes = {
     component: PropTypes.any,
-    render: PropTypes.any
+    render: PropTypes.any,
+    showNotes: PropTypes.bool
   };
 
   constructor (props, context) {
@@ -28,6 +29,7 @@ export default class Slide extends Component {
     const { presentation } = this.context
 
     this._pattern = presentation.getPatternForSlide(this)
+    this._slideIndex = presentation.getIndexForSlide(this)
   }
 
   componentWillUnmount () {
@@ -63,12 +65,13 @@ export default class Slide extends Component {
 
   _renderComponent () {
     const { presentation } = this.context
-    const { component: Component, render } = this.props
+    const { component: Component, render, showNotes } = this.props
+    const { _slideIndex: slideIndex } = this
 
     const stepIndex = presentation.getStepIndex()
 
     return typeof render === 'function'
-      ? render({ stepIndex })
-      : <Component stepIndex={stepIndex} />
+      ? render({ stepIndex, slideIndex, showNotes })
+      : <Component stepIndex={stepIndex} slideIndex={slideIndex} showNotes={showNotes} />
   }
 }


### PR DESCRIPTION
It's far from perfect, but it's good enough for me for now ;)

Injects a new prop `showNotes` into slide components, which will be displayed along with the slide itself in a new window.

```javascript
export default ({showNotes}) => (
  <div>
    {showNotes
      ? <div>Notes for this slide</div>
      : ''
    }
  </div>
)
```

**Features**

- Pressing `s`/`S` will trigger the notes to open in a new window.
- Allows showing the current slide and notes along side eachother in the new window
- Slides can be changed from both the main slide window _and_ the notes window