### PR TITLE
Avoid calling window.opener[this._parentWindowID] when it's missing

### DIFF
--- a/source/modules/PresenterModePlugin.js
+++ b/source/modules/PresenterModePlugin.js
@@ -104,7 +104,7 @@ export default class PresenterModePlugin extends Component {
   }
 
   _signalParent (path) {
-    if (!window.opener) {
+    if (!window.opener || typeof window.opener[this._parentWindowID] !== 'function') {
       return
     }
     window.opener[this._parentWindowID](path)


### PR DESCRIPTION
I'm using `create-react-app` to build a presentation and was trying to use presentation mode to debug. When I change my code, both pages refresh and the presenter mode loses its connection to the other window.