### PR TITLE
Upgrade react-router and react-router-dom to 4.0.0 and fix bug with content.router

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "cuid": "^1.3.8",
     "qs": "^6.3.0",
     "react-codemirror": "^0.2.6",
-    "react-router-dom": "^4.0.0-beta.6",
+    "react-router": "^4.0.0",
+    "react-router-dom": "^4.0.0",
     "react-virtualized-select": "^2.1.0",
     "styled-components": "^1.0.8"
   },

--- a/source/modules/Presentation.js
+++ b/source/modules/Presentation.js
@@ -164,7 +164,7 @@ class PresentationInner extends Component {
       const { router } = this.context
       const path = this._createPath({ slideIndex, stepIndex })
 
-      router.replace(path)
+      router.history.replace(path)
 
       this.forceUpdate()
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2388,9 +2388,9 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-history@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.5.1.tgz#44935a51021e3b8e67ebac267a35675732aba569"
+history@^4.5.1, history@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.6.1.tgz#911cf8eb65728555a94f2b12780a0c531a14d2fd"
   dependencies:
     invariant "^2.2.1"
     loose-envify "^1.2.0"
@@ -4000,21 +4000,22 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-router-dom@^4.0.0-beta.6:
-  version "4.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.0.0-beta.6.tgz#bdbd8f2fea3def52970735778db03b24cc082a02"
+react-router-dom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.0.0.tgz#4fa4418e14b8cfc5bcc0bdea0c4083fb8c2aef10"
   dependencies:
     history "^4.5.1"
-    react-router "^4.0.0-beta.6"
+    react-router "^4.0.0"
 
-react-router@^4.0.0-beta.6:
-  version "4.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.0.0-beta.6.tgz#561ac0bf1929960813bf201319ff85d821d5547b"
+react-router@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.0.0.tgz#6532075231f0bb5077c2005c1d417ad6165b3997"
   dependencies:
-    history "^4.5.1"
+    history "^4.6.0"
     invariant "^2.2.2"
     loose-envify "^1.3.1"
     path-to-regexp "^1.5.3"
+    warning "^3.0.0"
 
 react-select@^1.0.0-beta14:
   version "1.0.0-rc.3"


### PR DESCRIPTION
The `react-router@4.0.0` and `react-router-dom@4.0.0` were released, so there is an issue with `content.router`.